### PR TITLE
Add color management module to parking service

### DIFF
--- a/backend/Gateway/OcelotGateway/OcelotGateway/ocelot.json
+++ b/backend/Gateway/OcelotGateway/OcelotGateway/ocelot.json
@@ -93,6 +93,19 @@
       "UpstreamHttpMethod": ["GET"]
     },
     {
+      // Route cho ColorController
+      "DownstreamPathTemplate": "/colors/{everything}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "localhost",
+          "Port": 5000 // <-- THAY ĐỔI PORT NÀY NẾU CẦN
+        }
+      ],
+      "UpstreamPathTemplate": "/parking/colors/{everything}",
+      "UpstreamHttpMethod": ["GET", "POST", "PATCH", "DELETE"]
+    },
+    {
       // Route cho AppController (health check)
       "DownstreamPathTemplate": "/",
       "DownstreamScheme": "http",

--- a/backend/ParkSmart.postman_collection.json
+++ b/backend/ParkSmart.postman_collection.json
@@ -301,6 +301,130 @@
       "description": "Các API liên quan đến hãng xe"
     },
     {
+      "name": "Colors",
+      "item": [
+        {
+          "name": "Tạo màu sắc mới",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"colorName\": \"Red\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/parking/colors",
+              "host": ["{{baseUrl}}"],
+              "path": ["parking", "colors"]
+            },
+            "description": "Tạo một màu sắc mới. Yêu cầu xác thực Bearer Token."
+          },
+          "response": []
+        },
+        {
+          "name": "Lấy tất cả màu sắc",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/parking/colors",
+              "host": ["{{baseUrl}}"],
+              "path": ["parking", "colors"]
+            },
+            "description": "Lấy danh sách tất cả các màu sắc."
+          },
+          "response": []
+        },
+        {
+          "name": "Lấy màu sắc theo ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/parking/colors/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["parking", "colors", ":id"],
+              "variable": [
+                {
+                  "key": "id",
+                  "value": "your_color_id_here",
+                  "description": "ID của màu sắc cần tìm"
+                }
+              ]
+            },
+            "description": "Tìm và trả về thông tin của một màu sắc dựa trên ID."
+          },
+          "response": []
+        },
+        {
+          "name": "Xóa màu sắc theo ID",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/parking/colors/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["parking", "colors", ":id"],
+              "variable": [
+                {
+                  "key": "id",
+                  "value": "your_color_id_here",
+                  "description": "ID của màu sắc cần xóa"
+                }
+              ]
+            },
+            "description": "Xóa một màu sắc dựa trên ID. Yêu cầu xác thực Bearer Token."
+          },
+          "response": []
+        },
+        {
+          "name": "Khôi phục màu sắc theo ID",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/parking/colors/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["parking", "colors", ":id"],
+              "variable": [
+                {
+                  "key": "id",
+                  "value": "your_color_id_here",
+                  "description": "ID của màu sắc cần khôi phục"
+                }
+              ]
+            },
+            "description": "Khôi phục một màu sắc đã bị xóa dựa trên ID. Yêu cầu xác thực Bearer Token."
+          },
+          "response": []
+        }
+      ],
+      "description": "Các API liên quan đến màu sắc"
+    },
+    {
       "name": "Vehicle Types",
       "item": [
         {

--- a/backend/Services/parking-service/src/app.module.ts
+++ b/backend/Services/parking-service/src/app.module.ts
@@ -12,6 +12,7 @@ import { AddressModule } from './module/address/address.module'
 import { BrandModule } from './module/brand/brand.module'
 import { VehicleTypeModule } from './module/vehicleType/vehicleType.module'
 import { CacheModule } from '@nestjs/cache-manager'
+import { ColorModule } from './module/color/color.module'
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -37,6 +38,7 @@ import { CacheModule } from '@nestjs/cache-manager'
     AddressModule,
     BrandModule,
     VehicleTypeModule,
+    ColorModule,
   ],
   controllers: [AppController],
   providers: [AppService, JwtStrategy, JwtAuthGuard],

--- a/backend/Services/parking-service/src/module/color/color.controller.ts
+++ b/backend/Services/parking-service/src/module/color/color.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Inject,
+  UseGuards,
+  Req,
+  HttpStatus,
+} from '@nestjs/common'
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger'
+import { CreateColorDto } from './dto/createColor.dto'
+import { ColorResponseDto } from './dto/colorResponse.dto'
+import { IColorService } from './interfaces/icolorservice'
+import { JwtAuthGuard } from 'src/guard/jwtAuth.guard'
+import { RolesGuard } from 'src/guard/role.guard'
+import { Roles } from 'src/common/decorators/roles.decorator'
+import { RoleEnum } from 'src/common/enum/role.enum'
+import { ApiResponseDto } from 'src/common/dto/apiResponse.dto'
+
+@Controller('colors')
+@ApiTags('colors')
+export class ColorController {
+  constructor(
+    @Inject(IColorService) private readonly colorService: IColorService,
+  ) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(RoleEnum.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Tạo màu sắc mới' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Màu sắc đã được tạo thành công',
+    type: ApiResponseDto<ColorResponseDto>,
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'Màu sắc đã tồn tại',
+    type: ApiResponseDto,
+  })
+  async createColor(
+    @Body() createColorDto: CreateColorDto,
+    @Req() req,
+  ): Promise<ApiResponseDto<ColorResponseDto>> {
+    return this.colorService.createColor(createColorDto, req.user.id)
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Lấy tất cả màu sắc' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Danh sách màu sắc',
+    type: ApiResponseDto<ColorResponseDto[]>,
+  })
+  async getAllColors(): Promise<ApiResponseDto<ColorResponseDto>> {
+    return this.colorService.findAllColors()
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Lấy màu sắc theo ID' })
+  @ApiParam({ name: 'id', description: 'ID của màu sắc' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Màu sắc đã được tìm thấy',
+    type: ApiResponseDto<ColorResponseDto>,
+  })
+  async findColorById(
+    @Param('id') id: string,
+  ): Promise<ApiResponseDto<ColorResponseDto>> {
+    return this.colorService.findColorById(id)
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(RoleEnum.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Xóa màu sắc theo ID' })
+  @ApiParam({ name: 'id', description: 'ID của màu sắc' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Xóa màu sắc thành công',
+    type: ApiResponseDto<boolean>,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Xóa màu sắc thất bại',
+    type: ApiResponseDto,
+  })
+  async deleteColor(
+    @Param('id') id: string,
+    @Req() req,
+  ): Promise<ApiResponseDto<boolean>> {
+    return this.colorService.deleteColor(id, req.user.id)
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(RoleEnum.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Khôi phục màu sắc theo ID' })
+  @ApiParam({ name: 'id', description: 'ID của màu sắc' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Khôi phục màu sắc thành công',
+    type: ApiResponseDto<boolean>,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Khôi phục màu sắc thất bại',
+    type: ApiResponseDto,
+  })
+  async restoreColor(
+    @Param('id') id: string,
+    @Req() req,
+  ): Promise<ApiResponseDto<boolean>> {
+    return this.colorService.restoreColor(id, req.user.id)
+  }
+}

--- a/backend/Services/parking-service/src/module/color/color.module.ts
+++ b/backend/Services/parking-service/src/module/color/color.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common'
+import { MongooseModule } from '@nestjs/mongoose'
+import { Color, ColorSchema } from './schemas/color.schema'
+import { ColorController } from './color.controller'
+import { IColorService } from './interfaces/icolorservice'
+import { ColorService } from './color.service'
+import { IColorRepository } from './interfaces/icolor.repository'
+import { ColorRepository } from './color.repository'
+
+@Module({
+  imports: [
+    // Chỉ cần đăng ký một schema duy nhất
+    MongooseModule.forFeature([{ name: Color.name, schema: ColorSchema }]),
+  ],
+  controllers: [ColorController],
+  providers: [
+    {
+      provide: IColorService,
+      useClass: ColorService,
+    },
+    {
+      provide: IColorRepository,
+      useClass: ColorRepository,
+    },
+  ],
+  exports: [IColorRepository, IColorService],
+})
+export class ColorModule {}

--- a/backend/Services/parking-service/src/module/color/color.repository.ts
+++ b/backend/Services/parking-service/src/module/color/color.repository.ts
@@ -1,0 +1,52 @@
+import mongoose, { Model } from 'mongoose'
+import { CreateColorDto } from './dto/createColor.dto'
+import { Color } from './schemas/color.schema'
+import { IColorRepository } from './interfaces/icolor.repository'
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+
+@Injectable()
+export class ColorRepository implements IColorRepository {
+  constructor(
+    @InjectModel(Color.name) private readonly colorModel: Model<Color>,
+  ) {}
+
+  async createColor(color: CreateColorDto, userId: string): Promise<Color> {
+    const createdColor = new this.colorModel({
+      ...color,
+      createdAt: new Date(),
+      createdBy: new mongoose.Types.ObjectId(userId),
+    })
+    return createdColor.save()
+  }
+
+  async findAllColors(): Promise<Color[]> {
+    return this.colorModel.find().lean().exec()
+  }
+
+  async findColorById(id: string): Promise<Color | null> {
+    return this.colorModel.findById(id).lean().exec()
+  }
+
+  async findColorByName(name: string): Promise<Color | null> {
+    return this.colorModel.findOne({ colorName: name }).lean().exec()
+  }
+
+  async deleteColor(id: string, userId: string): Promise<boolean> {
+    const result = await this.colorModel.findByIdAndUpdate(id, {
+      deletedAt: new Date(),
+      deletedBy: new mongoose.Types.ObjectId(userId),
+    })
+    return result !== null
+  }
+
+  async restoreColor(id: string, userId: string): Promise<boolean> {
+    const result = await this.colorModel.findByIdAndUpdate(id, {
+      deletedAt: null,
+      deletedBy: null,
+      updatedAt: new Date(),
+      updatedBy: new mongoose.Types.ObjectId(userId),
+    })
+    return result !== null
+  }
+}

--- a/backend/Services/parking-service/src/module/color/color.service.ts
+++ b/backend/Services/parking-service/src/module/color/color.service.ts
@@ -1,0 +1,116 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common'
+import { CreateColorDto } from './dto/createColor.dto'
+import { IColorRepository } from './interfaces/icolor.repository'
+import { IColorService } from './interfaces/icolorservice'
+import { ApiResponseDto } from 'src/common/dto/apiResponse.dto'
+import { ColorResponseDto } from './dto/colorResponse.dto'
+import { isMongoId } from 'class-validator'
+import { ConfigService } from '@nestjs/config'
+
+@Injectable()
+export class ColorService implements IColorService {
+  constructor(
+    @Inject(IColorRepository)
+    private readonly colorRepository: IColorRepository,
+  ) {}
+
+  private readonly logger = new Logger(ColorService.name)
+  private readonly configService = new ConfigService()
+  private readonly accountServiceUrl =
+    this.configService.get<string>('CORE_SERVICE_URL')
+
+  async createColor(
+    createColorDto: CreateColorDto,
+    userId: string,
+  ): Promise<ApiResponseDto<ColorResponseDto>> {
+    const existingColor = await this.colorRepository.findColorByName(
+      createColorDto.colorName,
+    )
+    if (existingColor) {
+      throw new ConflictException('Màu sắc đã tồn tại')
+    }
+    const color = await this.colorRepository.createColor(createColorDto, userId)
+    return {
+      data: [new ColorResponseDto(color)],
+      statusCode: 201,
+      message: 'Màu sắc đã được tạo thành công',
+      success: true,
+    }
+  }
+
+  async findColorById(id: string): Promise<ApiResponseDto<any>> {
+    if (!isMongoId(id)) {
+      throw new BadRequestException('ID không hợp lệ')
+    }
+
+    const color = await this.colorRepository.findColorById(id)
+
+    if (!color) {
+      throw new NotFoundException('Không tìm thấy màu sắc')
+    }
+    return {
+      data: [new ColorResponseDto(color)],
+      statusCode: 200,
+      message: 'Tìm thấy màu sắc thành công',
+      success: true,
+    }
+  }
+
+  async findAllColors(): Promise<ApiResponseDto<ColorResponseDto>> {
+    const colors = await this.colorRepository.findAllColors()
+    if (!colors || colors.length === 0) {
+      throw new NotFoundException('Không tìm thấy màu sắc nào')
+    }
+    return {
+      data: colors.map((color) => new ColorResponseDto(color)),
+      statusCode: 200,
+      message: 'Tìm thấy tất cả màu sắc thành công',
+      success: true,
+    }
+  }
+
+  async deleteColor(
+    id: string,
+    userId: string,
+  ): Promise<ApiResponseDto<boolean>> {
+    if (!isMongoId(id)) {
+      throw new BadRequestException('ID không hợp lệ')
+    }
+    const success = await this.colorRepository.deleteColor(id, userId)
+    if (!success) {
+      throw new BadRequestException('Xóa màu sắc thất bại')
+    }
+    return {
+      data: [success],
+      statusCode: 200,
+      message: 'Xóa màu sắc thành công',
+      success: true,
+    }
+  }
+
+  async restoreColor(
+    id: string,
+    userId: string,
+  ): Promise<ApiResponseDto<boolean>> {
+    if (!isMongoId(id)) {
+      throw new BadRequestException('ID không hợp lệ')
+    }
+    const success = await this.colorRepository.restoreColor(id, userId)
+    if (!success) {
+      throw new BadRequestException('Khôi phục màu sắc thất bại')
+    }
+    return {
+      data: [success],
+      statusCode: 200,
+      message: 'Khôi phục màu sắc thành công',
+      success: true,
+    }
+  }
+}

--- a/backend/Services/parking-service/src/module/color/dto/colorResponse.dto.ts
+++ b/backend/Services/parking-service/src/module/color/dto/colorResponse.dto.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { ApiProperty } from '@nestjs/swagger'
+import { Transform } from 'class-transformer'
+import mongoose from 'mongoose'
+
+export class ColorResponseDto {
+  @ApiProperty({ example: '605e3f5f4f3e8c1d4c9f1e1z', type: String })
+  @Transform(({ value }) => value.toString(), { toPlainOnly: true })
+  _id: mongoose.Schema.Types.ObjectId
+
+  @ApiProperty({
+    example: 'Toyota',
+    type: String,
+  })
+  colorName: string
+
+  @ApiProperty({ example: null, type: String, nullable: true })
+  deletedBy: string
+
+  @ApiProperty({ example: null, type: Date, nullable: true })
+  deletedAt: Date | null
+
+  constructor(color: any) {
+    this._id = color._id
+    this.colorName = color.colorName
+    this.deletedAt = color.deletedAt
+    this.deletedBy = color.deletedBy
+  }
+}

--- a/backend/Services/parking-service/src/module/color/dto/createColor.dto.ts
+++ b/backend/Services/parking-service/src/module/color/dto/createColor.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { IsNotEmpty, IsString } from 'class-validator'
+
+export class CreateColorDto {
+  @ApiProperty({
+    example: 'Red',
+  })
+  @IsNotEmpty({ message: 'colorName không được để trống' })
+  @IsString()
+  colorName: string
+}

--- a/backend/Services/parking-service/src/module/color/interfaces/icolor.repository.ts
+++ b/backend/Services/parking-service/src/module/color/interfaces/icolor.repository.ts
@@ -1,0 +1,13 @@
+import { CreateColorDto } from '../dto/createColor.dto'
+import { Color } from '../schemas/color.schema'
+
+export interface IColorRepository {
+  createColor(color: CreateColorDto, userId: string): Promise<Color>
+  findAllColors(): Promise<Color[]>
+  findColorById(id: string): Promise<Color | null>
+  findColorByName(name: string): Promise<Color | null>
+  deleteColor(id: string, userId: string): Promise<boolean>
+  restoreColor(id: string, userId: string): Promise<boolean>
+}
+
+export const IColorRepository = Symbol('IColorRepository')

--- a/backend/Services/parking-service/src/module/color/interfaces/icolorservice.ts
+++ b/backend/Services/parking-service/src/module/color/interfaces/icolorservice.ts
@@ -1,0 +1,16 @@
+import { ApiResponseDto } from 'src/common/dto/apiResponse.dto'
+import { ColorResponseDto } from '../dto/colorResponse.dto'
+import { CreateColorDto } from '../dto/createColor.dto'
+
+export interface IColorService {
+  createColor(
+    createColorDto: CreateColorDto,
+    userId: string,
+  ): Promise<ApiResponseDto<ColorResponseDto>>
+  findColorById(id: string): Promise<ApiResponseDto<ColorResponseDto>>
+  findAllColors(): Promise<ApiResponseDto<ColorResponseDto>>
+  deleteColor(id: string, userId: string): Promise<ApiResponseDto<boolean>>
+  restoreColor(id: string, userId: string): Promise<ApiResponseDto<boolean>>
+}
+
+export const IColorService = Symbol('IColorService')

--- a/backend/Services/parking-service/src/module/color/schemas/color.schema.ts
+++ b/backend/Services/parking-service/src/module/color/schemas/color.schema.ts
@@ -1,0 +1,20 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import { HydratedDocument } from 'mongoose'
+import mongoose from 'mongoose'
+import { BaseEntity } from 'src/common/schema/baseEntity.schema'
+
+export type ColorDocument = HydratedDocument<Color>
+
+@Schema()
+export class Color extends BaseEntity {
+  @Prop({
+    type: mongoose.Schema.Types.ObjectId,
+    default: () => new mongoose.Types.ObjectId(),
+  })
+  _id: mongoose.Schema.Types.ObjectId
+
+  @Prop({ required: true, unique: true })
+  colorName: string
+}
+
+export const ColorSchema = SchemaFactory.createForClass(Color)


### PR DESCRIPTION
Introduces a new Color module with controller, service, repository, DTOs, interfaces, and schema for managing colors in the parking-service. Updates Ocelot gateway and Postman collection to support color-related API routes. Registers ColorModule in app.module for integration.