### PR TITLE
Add CORE_SERVICE_URL to deployment secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
             SMTP_HOST=${{ secrets.SMTP_HOST }}
             SMTP_PORT=${{ secrets.SMTP_PORT }}
             APP_NAME=${{ secrets.APP_NAME }}
+            CORE_SERVICE_URL=${{ secrets.CORE_SERVICE_URL }}
             EOF
             echo ">>> .env file created successfully."
 


### PR DESCRIPTION
Includes CORE_SERVICE_URL in the environment variables written to the .env file during deployment. This enables the application to access the core service URL from secrets.