### PR TITLE
Add WebSocket route for notifications in Ocelot config

### DIFF
--- a/backend/Gateway/OcelotGateway/OcelotGateway/ocelot.json
+++ b/backend/Gateway/OcelotGateway/OcelotGateway/ocelot.json
@@ -261,6 +261,20 @@
       "UpstreamHttpMethod": ["GET", "POST", "PATCH", "DELETE"]
     },
     {
+      "UpstreamPathTemplate": "/notifications/{everything}",
+      "UpstreamHttpMethod": ["GET"],
+      "UpstreamScheme": "ws", // Quan trọng: Báo cho Ocelot đây là kết nối WebSocket
+
+      "DownstreamScheme": "ws",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "parkingservice", // Vẫn là service NestJS của bạn
+          "Port": 5000
+        }
+      ],
+      "DownstreamPathTemplate": "/{everything}"
+    },
+    {
       "DownstreamPathTemplate": "/",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [


### PR DESCRIPTION
Introduced a new route in ocelot.json to proxy WebSocket connections for /notifications/{everything} to the parkingservice on port 5000. This enables WebSocket support for notification features through the gateway.